### PR TITLE
Engine dependency change forced by dependency change to Watson nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
         "start": "node --max-old-space-size=384 node_modules/node-red/red.js --settings ./bluemix-settings.js -v"
     },
     "engines": {
-        "node": "4.x"
+        "node": ">=4.5.0"
     }
 }


### PR DESCRIPTION
Minimum requirement imposed by SDK for watson-developer-cloud is for 

    "node": ">=4.5.0"