### PR TITLE
get/saveLibraryEntry substr() misused 

### DIFF
--- a/couchstorage.js
+++ b/couchstorage.js
@@ -308,7 +308,12 @@ var couchstorage = {
     },
 
     getLibraryEntry: function(type,path) {
-        var key = appname+"/lib/"+type+(path.substr(0)!="/"?"/":"")+path;
+        if (path != "" && path.substr(0,1) != "/") {
+            var key = appname+"/lib/"+type+"/"+path;
+        } else {
+            var key = appname+"/lib/"+type+path;
+        }
+        
         if (libraryCache[key]) {
             return when.resolve(libraryCache[key]);
         }
@@ -316,7 +321,7 @@ var couchstorage = {
         return when.promise(function(resolve,reject) {
             flowDb.get(key,function(err,doc) {
                 if (err) {
-                    if (path.substr(-1) == "/") {
+                    if (path.substr(-1,1) == "/") {
                         path = path.substr(0,path.length-1);
                     }
                     var qkey = [appname,type,path];
@@ -350,7 +355,12 @@ var couchstorage = {
         });
     },
     saveLibraryEntry: function(type,path,meta,body) {
-        if (path.substr(0) != "/") {
+
+        var p = path.split("/");    // strip multiple slash   
+        p = p.filter(Boolean);
+        path = p.slice(0,p.length).join("/")
+                
+        if (path != "" && path.substr(0,1) != "/") {
             path = "/"+path;
         }
         var key = appname+"/lib/"+type+path;


### PR DESCRIPTION
(not sure if this is the right way, since its my first contribution to an open project - please let me know if I did something wrong or should do something better) 

This fixes #10  (I opened this issue a month ago) 

Problems found / fixed:

1)   string.substr(start, length) 
length is optional & the number of characters to extract. If omitted, it extracts the rest of the string.
`if (path.substr(0) != "/") { ...};
` 
can't work.  replaced with:
`path.substr(0,1) != "/";
`


2)  empty path in  getLibraryEntry   
![screen shot 2017-04-03 at 15 41 59](https://cloud.githubusercontent.com/assets/16188530/24622566/c1b76b4c-18a5-11e7-949d-1784006772c2.png)
on empty path ( When "Open Library" is selected) it still adds a / to the key this prevents the refresh ( deleting from  libraryCache) to work.
( in getLibraryEntry the var path is later used in qkey so can't modify it similar as in saveLibraryEntry )  
snippet:
```
  if (path != "" && path.substr(0,1) != "/") {
           var key = appname+"/lib/"+type+"/"+path;
        } else {
            var key = appname+"/lib/"+type+path;
        }
```


3)  (add-on no problem fix) 
The gui checks that that filename ends with .js  but it does allow multiple slashes .  For instance:
![screen shot 2017-04-03 at 19 53 13](https://cloud.githubusercontent.com/assets/16188530/24622983/35c9aa08-18a7-11e7-9f3c-ee68b2aeb25e.png)
or even:
![screen shot 2017-04-03 at 19 55 06](https://cloud.githubusercontent.com/assets/16188530/24623050/797ddf6c-18a7-11e7-98dc-f85a13b38e11.png)
To avoid multiple slashes in the cloudant key  (gives a "undefined" entry in the UI dir listing)
multiple slashes are striped from the path with:
```
var p = path.split("/");    
p = p.filter(Boolean);
path = p.slice(0,p.length).join("/")
```
    
It should work (and its tested)  with my bluemix account. However there are probably still some unexpected things u can do with the dir / file name since its not really good checked.  