### PR TITLE
Package appmetrics-dash into NodeRED Bluemix Starter

### DIFF
--- a/bluemix-settings.js
+++ b/bluemix-settings.js
@@ -32,6 +32,9 @@ var settings = module.exports = {
     uiPort: process.env.PORT || 1880,
     mqttReconnectTime: 15000,
     debugMaxLength: 1000,
+    
+    //Flag for enabling Appmetrics dashboard (https://github.com/RuntimeTools/appmetrics-dash)
+    useAppmetrics: false,
 
     userDir: userDir,
 

--- a/index.js
+++ b/index.js
@@ -129,5 +129,10 @@ function startNodeRED(config) {
             util.log("Disabled anonymous read-only access - set NODE_RED_GUEST_ACCESS to 'true' to enable");
         }
     }
+    var dash;
+    if (settings.useAppmetrics || (process.env.NODE_RED_USE_APPMETRICS === 'true')) {
+    	dash = require('appmetrics-dash');
+    	dash.attach();
+    }
     require('./node_modules/node-red/red.js');
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name"         : "node-red-bluemix-starter",
     "version"      : "0.6.0",
     "dependencies": {
+        "appmetrics-dash": "^3.2.1",
         "when": "~3.x",
         "nano": "6.2.x",
         "bcrypt": "1.0.2",


### PR DESCRIPTION
@knolleary @tobespc Here's the PR for adding Appmetrics Dash into the Node-RED Bluemix starter. It can be enabled by setting the variable useAppmetrics in bluemix-settings.js to true, or by setting an environment variable NODE_RED_USE_APPMETRICS to true. Appmetrics-dash will attach to NodeRED's web server instance, and the dashboard will be on `hostname`:`port`/appmetrics-dash. Happy to write docs!

Signed-off-by: MattColegate <colegate@uk.ibm.com>