### PR TITLE
Allow appmetrics-dash to be enabled during first-run

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,8 +129,12 @@ function startNodeRED(config) {
             util.log("Disabled anonymous read-only access - set NODE_RED_GUEST_ACCESS to 'true' to enable");
         }
     }
+    if (config.useAppmetrics) {
+      settings.useAppmetrics = config.useAppmetrics;
+    }
     var dash;
-    if (settings.useAppmetrics || (process.env.NODE_RED_USE_APPMETRICS === 'true')) {
+    // ensure the environment variable overrides the settings
+    if ((process.env.NODE_RED_USE_APPMETRICS === 'true') || (settings.useAppmetrics && !(process.env.NODE_RED_USE_APPMETRICS === 'false'))) {
     	dash = require('appmetrics-dash');
     	dash.attach();
     }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -226,7 +226,7 @@ a.button:hover {
 }
 .body {
     position: absolute;
-    width: 400%;
+    width: 500%;
 }
 .toolbar {
     position: absolute;
@@ -264,7 +264,7 @@ button:disabled {
     vertical-align: top;
     display:inline-block;
     padding: 30px;
-    width: calc(25% - 5px);
+    width: calc(20% - 5px);
 }
 .hide {
     display:none;
@@ -349,7 +349,7 @@ input[type=text],input[type=password] {
 .progress-bar {
     display: inline-block;
     height: 100%;
-    width: calc((500px - (4*20px)) /3 );
+    width: calc((500px - (5*20px)) / 4 );
     background: url(../images/progress-bar.png) repeat-x 50% 50%;
 }
 .progress-bar.active {

--- a/public/first-run.html
+++ b/public/first-run.html
@@ -33,6 +33,7 @@
                         are a couple of tasks you should do:</p>
                     <ul>
                         <li>Secure your Node-RED editor</li>
+                        <li>Optionally enable <a href="https://developer.ibm.com/node/monitoring-post-mortem/application-metrics-node-js/" target="_blank">Application Metrics for Node.js</a> monitoring</li>
                         <li>Browse available IBM Bluemix nodes</li>
                     </ul>
                 </div>
@@ -57,6 +58,16 @@
                     </ul>
                 </div>
                 <div class="page page-3">
+                    <h3>Optionally enable <a href="https://developer.ibm.com/node/monitoring-post-mortem/application-metrics-node-js/" target="_blank">Application Metrics for Node.js</a> monitoring</h3>
+                    <p> Enabling this will allow you to monitor your Node-RED flows for metrics such as
+                        CPU usage, Memory usage, Heap usage, Event Loop useage, and HTTP request and response
+                        messages using a dashboard available at:</p>
+                    <p id="appmetrics"></p>
+                    <div><label class="checkboxLabel" for="enableAppmetrics"><input id="enableAppmetrics" type="checkbox"> Tick this box to confirm you want to enable
+                          <a href="https://developer.ibm.com/node/monitoring-post-mortem/application-metrics-node-js/" target="_blank">Application Metrics for Node.js</a>
+                    </label></div>
+                </div>
+                <div class="page page-4">
                     <h3>Browse available IBM Bluemix nodes</h3>
                     <p>There are lots of nodes available from the community that
                         can be used to add more capabilities to your application. The list below is just a small selection.</p>
@@ -77,7 +88,7 @@
                         </ul>
                     </div>
                 </div>
-                <div class="page page-4">
+                <div class="page page-5">
                     <h3>Finish the install</h3>
                     <p>You have made the following selections:</p>
                     <ul id="summary"></ul>
@@ -86,6 +97,7 @@
                         <li><code>NODE_RED_USERNAME</code> - the username</li>
                         <li><code>NODE_RED_PASSWORD</code> - the password</li>
                         <li><code>NODE_RED_GUEST_ACCESS</code> - if set to `true`, allows anyone read-only access to the editor</li>
+                        <li><code>NODE_RED_USE_APPMETRICS</code> - if set to `true`, enables the <a href="https://developer.ibm.com/node/monitoring-post-mortem/application-metrics-node-js/" target="_blank">Application Metrics for Node.js</a> dashboard for monitoring your Node-RED flows</li>
                     </ul>
                 </div>
 
@@ -99,6 +111,8 @@
                     <div class="progress-step progress-step-2"></div>
                     <div class="progress-bar progress-bar-3"></div>
                     <div class="progress-step progress-step-3"></div>
+                    <div class="progress-bar progress-bar-4"></div>
+                    <div class="progress-step progress-step-4"></div>
                 </div>
                 <div class="btn-group">
                     <button id="btn-prev">Previous</button>
@@ -111,7 +125,7 @@
         <script>
         $(function() {
             var currentPage = 0;
-            var totalPages = 4;
+            var totalPages = 5;
             var passwordValid = false;
 
             var password;
@@ -151,7 +165,11 @@
                     currentPage++;
                     if (currentPage === 1) {
                         $("#secureOption-password").val(password);
-                    } else if (currentPage === 3) {
+                    } else if (currentPage === 2) {
+                        var appmetrics = $("#appmetrics");
+                        appmetrics.empty();
+                        $("<span>" + location.origin + "/appmetrics-dash</span>").appendTo(appmetrics);
+                    } else if (currentPage === 4) {
                         var summary = $("#summary");
                         summary.empty();
                         var v = $('input[name=secureOption]:checked').val();
@@ -166,14 +184,16 @@
                             $("<li>None - please go back and make a selection</li>").appendTo(summary);
 
                         }
-
+                        if ($("#enableAppmetrics").prop("checked")) {
+                            $('<li>Enable <a href="https://developer.ibm.com/node/monitoring-post-mortem/application-metrics-node-js/" target="_blank">Application Metrics for Node.js</a> monitoring</li>').appendTo(summary);
+                        }
                     }
                     $(".body").animate({
                         left: "-"+currentPage+"00%"
-                    })
+                    });
                     updateProgress();
                 }
-            })
+            });
             $("#btn-prev").click(function(e) {
                 e.preventDefault();
                 if (currentPage > 0) {
@@ -185,19 +205,23 @@
                     currentPage--;
                     if (currentPage === 1) {
                         $("#secureOption-password").val(password);
+                    } else if (currentPage === 2) {
+                        var appmetrics = $("#appmetrics");
+                        appmetrics.empty();
+                        $("<span>" + location.origin + "/appmetrics-dash</span>").appendTo(appmetrics);
                     }
                     $(".body").animate({
                         left: "-"+currentPage+"00%"
-                    })
+                    });
                     updateProgress();
                 }
-            })
+            });
             $(".body").css({
                 left: "-"+currentPage+"00%"
-            })
+            });
             $('#secureOption-username').on('keyup',function() {
                 updateProgress();
-            })
+            });
             $('input[name=secureOption]').on('change', function() {
                 updateProgress();
                 var v = $('input[name=secureOption]:checked').val();
@@ -213,7 +237,7 @@
 
             $("#secureOption-insecure").on('change', function() {
                 updateProgress();
-            })
+            });
             var meter = $("#password-meter");
             var strengthColors = [
                 "red","red","red","yellowgreen","green"
@@ -252,6 +276,7 @@
                         allowAnonymous: $("#secureOption-anonymous").prop("checked")
                     };
                 }
+                config.useAppmetrics = $("#enableAppmetrics").prop("checked");
                 $(".body").hide();
                 $(".toolbar").hide();
                 $(".deploy").show();

--- a/public/index.html
+++ b/public/index.html
@@ -87,6 +87,33 @@
                             </div>
                         </li>
                         <li>
+                            <h4 id="enabling-appmetrics"> + Enabling Application Metrics for Node.js monitoring</h4>
+                            <div class="custom-content">
+                                <p>When you first ran this application you were presented with an option to enable monitoring of your Node-RED
+                                    flows using the <a href="https://developer.ibm.com/node/monitoring-post-mortem/application-metrics-node-js/" target="_blank">Application Metrics for Node.js</a>
+                                    dashboard. To change those options, you can set an environment variable from either the Bluemix console or the <code>cf</code> command-line
+                                </p>
+                                <p>When enabled, the <a href="https://developer.ibm.com/node/monitoring-post-mortem/application-metrics-node-js/" target="_blank">Application Metrics for Node.js</a> dashboard will be available at </p>
+                                <p id="appdashURL"></p>
+                                <p>The environment variable you can set is:</p>
+                                <ul>
+                                    <li><code>NODE_RED_USE_APPMETRICS</code> - set to <code>true</code> to enable <a href="https://developer.ibm.com/node/monitoring-post-mortem/application-metrics-node-js/" target="_blank">Application Metrics for Node.js</a>
+                                         monitoring. Set to <code>false</code> to disable.
+                                    </li>
+                                </ul>
+                                <h5>Bluemix console</h5>
+                                <ol>
+                                    <li>On the Bluemix console page for this application, go to the 'Runtime' page and then the 'Environment Variables' section</li>
+                                    <li>Add the required user-defined variable</li>
+                                    <li>Click <code>Save</code> and restart your application</li>
+                                </ol>
+                                <h5><code>cf</code> command-line</h5>
+                                <ol>
+                                    <li>Run the command: <pre>cf set-env [APPLICATION_NAME] [ENV_VAR_NAME] [ENV_VAR_VALUE]</pre></li>
+                                </ol>
+                            </div>
+                        </li>
+                        <li>
                             <h4> + Adding new nodes to the palette</h4>
                             <div class="custom-content">
                                 <p>There is a growing collection of additional nodes that can be added to the Node-RED editor.
@@ -178,6 +205,10 @@
     </div>
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
     <script>
+    var appdashURL = $("#appdashURL");
+    var urlString = location.origin + "/appmetrics-dash";
+    appdashURL.empty();
+    $('<a href="' + urlString + '" target="_blank">' + urlString + '</a>').appendTo(appdashURL);
 
     $(function() {
         $("ul.customisations h4").click(function(ev) {


### PR DESCRIPTION
Signed-off-by: MattColegate <colegate@uk.ibm.com>
@knolleary @tobespc Here's the second half of the appmetrics-dash work - adding an appmetrics screen into the first-run web page with an enabling checkbox. I've also added an appmetrics section to the Node-RED index.html, and improved the turn off/on logic so that the appmetrics environment variable overrides the settings file.