### PR TITLE
Solve link problem for nodered.org

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -184,21 +184,21 @@
                 <ul>
                     <li><a href="https://github.com/node-red">GitHub</a></li>
                     <li><a href="https://www.npmjs.com/package/node-red">npm</a></li>
-                    <li><a href="/docs">Documentation</a></li>
+                    <li><a href="https://nodered.org/docs">Documentation</a></li>
                 </ul>
             </div>
             <div class="col-1-6">
                 <ul>
                     <li><a href="https://flows.nodered.org">Flow Library</a></li>
-                    <li><a href="/about/">About</a></li>
+                    <li><a href="https://nodered.org/about/">About</a></li>
                 </ul>
             </div>
             <div class="col-1-6">
                 <ul>
-                    <li><a href="/blog">Blog</a></li>
+                    <li><a href="https://nodered.org/blog/">Blog</a></li>
                     <li><a href="https://twitter.com/nodered">Twitter</a></li>
                     <li><a href="https://groups.google.com/forum/#!forum/node-red">Mailing List</a></li>
-                    <li><a href="/slack">Slack</a></li>
+                    <li><a href="https://nodered.org/slack">Slack</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Current index.html file contains invalid links because it uses relative URLs. So I changed the relative URLs into absolute URLs.