### PR TITLE
fix error when trying to start node-red locally.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,10 @@ if (!settings.adminAuth) {
         storage = settings.storageModule;
     } else {
         storage = require('./node_modules/node-red/red/runtime/storage/localfilesystem');
+        runtime = require('./node_modules/node-red/red/runtime');
     }
     util.log("Loading application settings");
-    storage.init(settings).then(storage.getSettings).then(function(runtimeSettings) {
+    storage.init(settings, runtime).then(storage.getSettings).then(function(runtimeSettings) {
         if (process.env.NODE_RED_USERNAME && process.env.NODE_RED_PASSWORD) {
             util.log("Enabling adminAuth using NODE_RED_USERNAME/NODE_RED_PASSWORD");
             var config = {


### PR DESCRIPTION
version 0.9.0 fails to `npm start` locally (i.e. no bound cloudant instance):

```shell
> npm start

> node-red-app@0.9.0 start R:\node-red-bluemix-starter
> node --max-old-space-size=160 index.js --settings ./bluemix-settings.js -v

10 Dec 01:38:58 - Starting Node-RED on IBM Cloud bootstrap
10 Dec 01:38:58 - Loading bluemix-settings.js
10 Dec 01:38:59 - Failed to find Cloudant service: /^node-red-app.cloudantNoSQLDB/
10 Dec 01:38:59 - Loading application settings
R:\node-red-bluemix-starter\node_modules\node-red\red\runtime\storage\localfilesystem\projects\index.js:45
    log = runtime.log;
                  ^

TypeError: Cannot read property 'log' of undefined
    at Object.init (R:\node-red-bluemix-starter\node_modules\node-red\red\runtime\storage\localfilesystem\projects\index.js:45:19)
    at Object.init (R:\node-red-bluemix-starter\node_modules\node-red\red\runtime\storage\localfilesystem\index.js:62:32)
    at Object.<anonymous> (R:\node-red-bluemix-starter\index.js:36:13)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-red-app@0.9.0 start: `node --max-old-space-size=160 index.js --settings ./bluemix-settings.js -v`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the node-red-app@0.9.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     D:\Users\rophy\npm-cache\_logs\2018-12-09T17_38_59_995Z-debug.log
```

This PR fixes the error so that `npm start` works without cloudant.